### PR TITLE
Issue-29: [Domain] Store unique_ptr<Building> and unique_ptr<Landmark…

### DIFF
--- a/models/architecture_market.cpp
+++ b/models/architecture_market.cpp
@@ -46,12 +46,6 @@ ArchitectureMarket::ArchitectureMarket()
     addBuildings(CardName::FAMILY_RESTAURANT, FamilyRestaurant{}, 6);
     addBuildings(CardName::APPLE_ORCHARD, AppleOrchard{}, 6);
     addBuildings(CardName::FRUIT_AND_VEGETABLE_MARKET, FruitAndVegetableMarket{}, 6);
-
-    // Landmarks.
-    addBuildings(CardName::AMUSEMENT_PARK, AmusementPark{}, 4);
-    addBuildings(CardName::RADIO_TOWER, RadioTower{}, 4);
-    addBuildings(CardName::SHOPPING_MALL, ShoppingMall{}, 4);
-    addBuildings(CardName::TRAIN_STATION, TrainStation{}, 4);
 }
 
 ArchitectureMarket::~ArchitectureMarket()
@@ -61,12 +55,12 @@ ArchitectureMarket::~ArchitectureMarket()
     buildings_.clear();
 }
 
-std::vector<std::unique_ptr<Card>> ArchitectureMarket::GetInitialBuildingsForOnePlayer()
+std::vector<std::unique_ptr<Building>> ArchitectureMarket::GetInitialBuildingsForOnePlayer()
 {
     // 每個玩家一開始都各持有一張小麥田和麵包店。
-    std::vector<std::unique_ptr<Card>> cards;
-    assert(buildings_[CardName::WHEAT_FIELD].size() > 0 && "There is no wheat field card in the market.");   
-    assert(buildings_[CardName::BAKERY].size() > 0 && "There is no bakery card in the market.");   
+    std::vector<std::unique_ptr<Building>> cards;
+    assert(buildings_[CardName::WHEAT_FIELD].size() > 0 && "There is no wheat field card in the market.");
+    assert(buildings_[CardName::BAKERY].size() > 0 && "There is no bakery card in the market.");
     cards.push_back(std::move(buildings_[CardName::WHEAT_FIELD].back()));
     cards.push_back(std::move(buildings_[CardName::BAKERY].back()));
     buildings_[CardName::WHEAT_FIELD].pop_back();
@@ -74,25 +68,13 @@ std::vector<std::unique_ptr<Card>> ArchitectureMarket::GetInitialBuildingsForOne
     return cards;
 }
 
-std::vector<std::unique_ptr<Card>> ArchitectureMarket::GetLandmarksForOnePlayer()
+std::vector<std::unique_ptr<Landmark>> ArchitectureMarket::GetLandmarksForOnePlayer()
 {
     // 每個玩家一開始各分到一張主題樂園、一張廣播電台、一張購物中心，以及一張火車站。
-    std::vector<std::unique_ptr<Card>> cards;
-    assert(buildings_[CardName::AMUSEMENT_PARK].size() > 0 && 
-        "There is no amusement park card in the market.");
-    assert(buildings_[CardName::SHOPPING_MALL].size() > 0 && 
-        "There is no shopping mall card in the market.");
-    assert(buildings_[CardName::TRAIN_STATION].size() > 0 && 
-        "There is no train station card in the market.");
-    assert(buildings_[CardName::RADIO_TOWER].size() > 0 && 
-        "There is no radio tower card in the market.");
-    cards.push_back(std::move(buildings_[CardName::AMUSEMENT_PARK].back()));
-    cards.push_back(std::move(buildings_[CardName::SHOPPING_MALL].back()));
-    cards.push_back(std::move(buildings_[CardName::TRAIN_STATION].back()));
-    cards.push_back(std::move(buildings_[CardName::RADIO_TOWER].back()));
-    buildings_[CardName::AMUSEMENT_PARK].pop_back();
-    buildings_[CardName::SHOPPING_MALL].pop_back();
-    buildings_[CardName::TRAIN_STATION].pop_back();
-    buildings_[CardName::RADIO_TOWER].pop_back();
+    std::vector<std::unique_ptr<Landmark>> cards;
+    cards.push_back(std::make_unique<AmusementPark>());
+    cards.push_back(std::make_unique<ShoppingMall>());
+    cards.push_back(std::make_unique<TrainStation>());
+    cards.push_back(std::make_unique<RadioTower>());
     return cards;
 }

--- a/models/architecture_market.h
+++ b/models/architecture_market.h
@@ -7,7 +7,6 @@
 #include <deque>
 #include <memory>
 
-#include "./card/card.h"
 #include "./card/landmark.h"
 #include "./card/building.h"
 
@@ -19,15 +18,15 @@ public:
     ArchitectureMarket& operator = (const ArchitectureMarket& rhs) = delete;
     ArchitectureMarket& operator = (ArchitectureMarket&& rhs) = delete;
 
-    std::vector<std::unique_ptr<Card>> GetInitialBuildingsForOnePlayer();
-    std::vector<std::unique_ptr<Card>> GetLandmarksForOnePlayer();
+    std::vector<std::unique_ptr<Building>> GetInitialBuildingsForOnePlayer();
+    std::vector<std::unique_ptr<Landmark>> GetLandmarksForOnePlayer();
 
-    const std::map<CardName, std::deque<std::unique_ptr<Card>>>&
+    const std::map<CardName, std::deque<std::unique_ptr<Building>>>&
     get_buildings() const { return buildings_; }
 
 private:
     // key: Card name; Value : Cards.
-    std::map<CardName, std::deque<std::unique_ptr<Card>>> buildings_;
+    std::map<CardName, std::deque<std::unique_ptr<Building>>> buildings_;
 };
 
 #endif

--- a/models/hand.cpp
+++ b/models/hand.cpp
@@ -12,17 +12,17 @@ Hand::~Hand()
     landmarks_.clear();
 }
 
-std::vector<Card*> Hand::get_buildings() const
+std::vector<Building*> Hand::get_buildings() const
 {
-    std::vector<Card*> res;
+    std::vector<Building*> res;
     for (const auto& card : buildings_)
         res.push_back(card.get());
     return res;
 }
 
-std::vector<Card*> Hand::get_landmarks() const
+std::vector<Landmark*> Hand::get_landmarks() const
 {
-    std::vector<Card*> res;
+    std::vector<Landmark*> res;
     for (const auto& card: landmarks_)
         res.push_back(card.get());
     return res;

--- a/models/hand.h
+++ b/models/hand.h
@@ -4,28 +4,30 @@
 #include <vector>
 #include <memory>
 
-#include "card/card.h"
+#include "card/building.h"
+#include "card/landmark.h"
 
-class Card;
+class Building;
+class Landmark;
 
 class Hand {
 public:
     Hand();
     ~Hand();
 
-    void AddBuilding(std::unique_ptr<Card> card) 
+    void AddBuilding(std::unique_ptr<Building> card)
     { buildings_.push_back(std::move(card)); }
 
-    void AddLandmark(std::unique_ptr<Card> card) 
+    void AddLandmark(std::unique_ptr<Landmark> card)
     { landmarks_.push_back(std::move(card)); }
 
-    std::vector<Card*> get_buildings() const;
+    std::vector<Building*> get_buildings() const;
 
-    std::vector<Card*> get_landmarks() const;
+    std::vector<Landmark*> get_landmarks() const;
 
 private:
-    std::vector<std::unique_ptr<Card>> buildings_;
-    std::vector<std::unique_ptr<Card>> landmarks_;
+    std::vector<std::unique_ptr<Building>> buildings_;
+    std::vector<std::unique_ptr<Landmark>> landmarks_;
 };
 
 #endif

--- a/models/machikoro_game.cpp
+++ b/models/machikoro_game.cpp
@@ -50,22 +50,22 @@ std::vector<Player*> MachiKoroGame::get_players()
     return players;
 }
 
-std::unique_ptr<DomainEvent> 
-MachiKoroGame::RollDice(const std::string& player_id, int dice_count) 
+std::unique_ptr<DomainEvent>
+MachiKoroGame::RollDice(const std::string& player_id, int dice_count)
 {
-    auto IsLandmarkInHand = 
+    auto IsLandmarkInHand =
         [](const Hand* hand, const CardName name) -> bool {
             auto it = std::find_if(
                 hand->get_landmarks().begin(),
                 hand->get_landmarks().end(),
-                [&name](Card* landmark)  { 
+                [&name](Landmark* landmark)  {
                     return landmark->get_name() == name &&
-                        dynamic_cast<Landmark*>(landmark)->IsActivate();
+                           landmark->IsActivate();
                 }
             );
             return it != hand->get_landmarks().end();
         };
-    
+
     // Idnetify current player.
     auto player = (*std::find_if(players_.begin(), players_.end(),
         [&player_id](const auto& p) { return p->get_name() == player_id; }
@@ -81,7 +81,7 @@ MachiKoroGame::RollDice(const std::string& player_id, int dice_count)
         return event;
     }
 
-    // Operate effect. 
+    // Operate effect.
 
     // If two points are the same, can roll the dice in next round or not.
     if (pt1 == pt2 &&

--- a/models/player.cpp
+++ b/models/player.cpp
@@ -23,11 +23,11 @@ Player::~Player()
 std::pair<int, int> Player::RollDice(int dice_count)
 {
     auto it = std::find_if(
-        hand_->get_landmarks().begin(), 
+        hand_->get_landmarks().begin(),
         hand_->get_landmarks().end(),
-        [](Card* landmark) {
+        [](Landmark* landmark) {
             return landmark->get_name() == CardName::TRAIN_STATION &&
-                dynamic_cast<Landmark*>(landmark)->IsActivate();
+                   landmark->IsActivate();
         }
     );
 
@@ -43,7 +43,7 @@ std::pair<int, int> Player::RollDice(int dice_count)
     if (dice_count == 2)
         pt2 = dice_.GeneratePoint();
 
-    return std::make_pair(pt1, pt2); 
+    return std::make_pair(pt1, pt2);
 }
 
 void Player::PayCoin(int coin)
@@ -62,13 +62,13 @@ void Player::PayCoin2AnotherPlayer(int coin, Player* other)
     other->GainCoin(coin);
 }
 
-void Player::GainLandmarks(std::vector<std::unique_ptr<Card>>&& cards)
+void Player::GainLandmarks(std::vector<std::unique_ptr<Landmark>>&& cards)
 {
     for (auto& card : cards)
         hand_->AddLandmark(std::move(card));
 }
 
-void Player::GainInitialBuildings(std::vector<std::unique_ptr<Card>>&& cards)
+void Player::GainInitialBuildings(std::vector<std::unique_ptr<Building>>&& cards)
 {
     for (auto& card : cards)
         hand_->AddBuilding(std::move(card));

--- a/models/player.h
+++ b/models/player.h
@@ -9,6 +9,7 @@
 #include "dice.h"
 #include "hand.h"
 #include "card/building.h"
+#include "card/landmark.h"
 
 class Card;
 class Hand;
@@ -32,9 +33,9 @@ public:
 
     void PayCoin2AnotherPlayer(int coin, Player* other);
 
-    void GainLandmarks(std::vector<std::unique_ptr<Card>>&& cards);
+    void GainLandmarks(std::vector<std::unique_ptr<Landmark>>&& cards);
 
-    void GainInitialBuildings(std::vector<std::unique_ptr<Card>>&& cards);
+    void GainInitialBuildings(std::vector<std::unique_ptr<Building>>&& cards);
 
     int get_coin() const { return coin_; }
 

--- a/test/e2e_test/game_setup_e2etest.cpp
+++ b/test/e2e_test/game_setup_e2etest.cpp
@@ -110,7 +110,7 @@ TEST_F(GameSetupE2ETest, CreateGameSuccessfully)
         EXPECT_EQ(hand->get_landmarks().size(), 4);
         for (const auto& landmark: hand->get_landmarks()) {
             EXPECT_NE(std::find(card_names.begin(), card_names.end(), landmark->get_name()), card_names.end());
-            EXPECT_FALSE(dynamic_cast<Landmark*>(landmark)->IsActivate());
+            EXPECT_FALSE(landmark->IsActivate());
         }
     }
 

--- a/test/unittest/game_unittest.cpp
+++ b/test/unittest/game_unittest.cpp
@@ -14,7 +14,7 @@ protected:
         std::vector<std::string> names = {"Alice", "Bob", "Cindy", "David"};
         game_ = std::make_unique<MachiKoroGame>(names);
     }
-    
+
     virtual void TearDown() override {
         game_.reset();
     }
@@ -29,6 +29,6 @@ TEST_F(GameTest, GameInit) {
         EXPECT_EQ(player->get_hand()->get_landmarks().size(), 4);
         EXPECT_EQ(player->get_coin(), 3);
     }
-    // 19 types of cards
-    EXPECT_EQ(game_->get_market()->get_buildings().size(), 19);
+    // 15 types of buildings (landmarks are not included)
+    EXPECT_EQ(game_->get_market()->get_buildings().size(), 15);
 }


### PR DESCRIPTION
…> instead of unique_ptr<Card>

Separate pointers to Card into pointers to Building and Landmark in the following class:
* Architecture market
* Player
* Hand

Architecture market creates Landmarks when distributing them to players. Architecture market doesn't need to store them.