### PR TITLE
43.change the type in init game event (#43)

### DIFF
--- a/cmake/sources.cmake
+++ b/cmake/sources.cmake
@@ -4,20 +4,20 @@ set(CONTROLLER_HEADERS
     ${CMAKE_SOURCE_DIR}/controllers/clear_game_controller.h
 )
 set(CONTROLLER_SOURCES
-    ${CMAKE_SOURCE_DIR}/controllers/create_game_controller.cpp
     ${CMAKE_SOURCE_DIR}/controllers/clear_game_controller.cpp
+    ${CMAKE_SOURCE_DIR}/controllers/create_game_controller.cpp
     ${CMAKE_SOURCE_DIR}/controllers/init_game_controller.cpp
 )
 set(PRESENTER_HEADERS
     ${CMAKE_SOURCE_DIR}/presenters/create_game_present.h
+    ${CMAKE_SOURCE_DIR}/presenters/init_game_present.h
     ${CMAKE_SOURCE_DIR}/presenters/clear_game_present.h
     ${CMAKE_SOURCE_DIR}/presenters/presenter.h
-    ${CMAKE_SOURCE_DIR}/presenters/init_game_present.h
 )
 set(PRESENTER_SOURCES
     ${CMAKE_SOURCE_DIR}/presenters/create_game_present.cpp
-    ${CMAKE_SOURCE_DIR}/presenters/init_game_present.cpp
     ${CMAKE_SOURCE_DIR}/presenters/clear_game_present.cpp
+    ${CMAKE_SOURCE_DIR}/presenters/init_game_present.cpp
 )
 set(LOGGER_HEADERS
     ${CMAKE_SOURCE_DIR}/loggers/logger_base.h
@@ -27,99 +27,101 @@ set(LOGGER_SOURCES
     ${CMAKE_SOURCE_DIR}/loggers/logger.cpp
 )
 set(REPO_HEADERS
-    ${CMAKE_SOURCE_DIR}/repos/memory_repository.h
     ${CMAKE_SOURCE_DIR}/repos/repository.h
+    ${CMAKE_SOURCE_DIR}/repos/memory_repository.h
 )
 set(REPO_SOURCES
     ${CMAKE_SOURCE_DIR}/repos/memory_repository.cpp
 )
 set(UTIL_HEADERS
-    ${CMAKE_SOURCE_DIR}/utils/util_base.h
     ${CMAKE_SOURCE_DIR}/utils/util.h
+    ${CMAKE_SOURCE_DIR}/utils/util_base.h
 )
 set(UTIL_SOURCES
     ${CMAKE_SOURCE_DIR}/utils/util.cpp
 )
 set(USECASE_HEADERS
-    ${CMAKE_SOURCE_DIR}/usecases/create_game.h
     ${CMAKE_SOURCE_DIR}/usecases/clear_game.h
+    ${CMAKE_SOURCE_DIR}/usecases/create_game.h
     ${CMAKE_SOURCE_DIR}/usecases/init_game.h
 )
 set(USECASE_SOURCES
     ${CMAKE_SOURCE_DIR}/usecases/create_game.cpp
-    ${CMAKE_SOURCE_DIR}/usecases/init_game.cpp
     ${CMAKE_SOURCE_DIR}/usecases/clear_game.cpp
+    ${CMAKE_SOURCE_DIR}/usecases/init_game.cpp
 )
 set(MODEL_HEADERS
-    ${CMAKE_SOURCE_DIR}/models/dice.h
-    ${CMAKE_SOURCE_DIR}/models/bank.h
-    ${CMAKE_SOURCE_DIR}/models/machikoro_game.h
-    ${CMAKE_SOURCE_DIR}/models/architecture_market.h
     ${CMAKE_SOURCE_DIR}/models/dice_base.h
-    ${CMAKE_SOURCE_DIR}/models/player.h
-    ${CMAKE_SOURCE_DIR}/models/events/init_game_event.h
-    ${CMAKE_SOURCE_DIR}/models/events/create_game_event.h
-    ${CMAKE_SOURCE_DIR}/models/events/clear_game_event.h
-    ${CMAKE_SOURCE_DIR}/models/events/event.h
-    ${CMAKE_SOURCE_DIR}/models/hand.h
-    ${CMAKE_SOURCE_DIR}/models/cards/radio_tower.h
-    ${CMAKE_SOURCE_DIR}/models/cards/stadium.h
-    ${CMAKE_SOURCE_DIR}/models/cards/card.h
-    ${CMAKE_SOURCE_DIR}/models/cards/ranch.h
-    ${CMAKE_SOURCE_DIR}/models/cards/amusement_park.h
-    ${CMAKE_SOURCE_DIR}/models/cards/mine.h
-    ${CMAKE_SOURCE_DIR}/models/cards/tv_station.h
+    ${CMAKE_SOURCE_DIR}/models/architecture_market.h
+    ${CMAKE_SOURCE_DIR}/models/cards/convenient_store.h
+    ${CMAKE_SOURCE_DIR}/models/cards/fruit_and_vegetable_market.h
     ${CMAKE_SOURCE_DIR}/models/cards/wheat_field.h
+    ${CMAKE_SOURCE_DIR}/models/cards/card.h
+    ${CMAKE_SOURCE_DIR}/models/cards/shopping_mall.h
+    ${CMAKE_SOURCE_DIR}/models/cards/cheese_factory.h
+    ${CMAKE_SOURCE_DIR}/models/cards/forest.h
+    ${CMAKE_SOURCE_DIR}/models/cards/ranch.h
     ${CMAKE_SOURCE_DIR}/models/cards/cafe.h
     ${CMAKE_SOURCE_DIR}/models/cards/family_restaurant.h
-    ${CMAKE_SOURCE_DIR}/models/cards/apple_orchard.h
-    ${CMAKE_SOURCE_DIR}/models/cards/business_center.h
+    ${CMAKE_SOURCE_DIR}/models/cards/radio_tower.h
     ${CMAKE_SOURCE_DIR}/models/cards/landmark.h
     ${CMAKE_SOURCE_DIR}/models/cards/building.h
-    ${CMAKE_SOURCE_DIR}/models/cards/cheese_factory.h
+    ${CMAKE_SOURCE_DIR}/models/cards/tv_station.h
     ${CMAKE_SOURCE_DIR}/models/cards/bakery.h
-    ${CMAKE_SOURCE_DIR}/models/cards/fruit_and_vegetable_market.h
-    ${CMAKE_SOURCE_DIR}/models/cards/shopping_mall.h
-    ${CMAKE_SOURCE_DIR}/models/cards/convenient_store.h
+    ${CMAKE_SOURCE_DIR}/models/cards/amusement_park.h
+    ${CMAKE_SOURCE_DIR}/models/cards/stadium.h
+    ${CMAKE_SOURCE_DIR}/models/cards/apple_orchard.h
     ${CMAKE_SOURCE_DIR}/models/cards/furniture_factory.h
-    ${CMAKE_SOURCE_DIR}/models/cards/forest.h
     ${CMAKE_SOURCE_DIR}/models/cards/train_station.h
+    ${CMAKE_SOURCE_DIR}/models/cards/business_center.h
+    ${CMAKE_SOURCE_DIR}/models/cards/mine.h
+    ${CMAKE_SOURCE_DIR}/models/hand.h
+    ${CMAKE_SOURCE_DIR}/models/player.h
+    ${CMAKE_SOURCE_DIR}/models/machikoro_game.h
+    ${CMAKE_SOURCE_DIR}/models/bank.h
+    ${CMAKE_SOURCE_DIR}/models/events/clear_game_event.h
+    ${CMAKE_SOURCE_DIR}/models/events/init_game_event.h
+    ${CMAKE_SOURCE_DIR}/models/events/event.h
+    ${CMAKE_SOURCE_DIR}/models/events/create_game_event.h
+    ${CMAKE_SOURCE_DIR}/models/events/event_player.h
+    ${CMAKE_SOURCE_DIR}/models/dice.h
 )
 set(MODEL_SOURCES
-    ${CMAKE_SOURCE_DIR}/models/dice.cpp
-    ${CMAKE_SOURCE_DIR}/models/machikoro_game.cpp
     ${CMAKE_SOURCE_DIR}/models/bank.cpp
     ${CMAKE_SOURCE_DIR}/models/player.cpp
-    ${CMAKE_SOURCE_DIR}/models/hand.cpp
+    ${CMAKE_SOURCE_DIR}/models/dice.cpp
+    ${CMAKE_SOURCE_DIR}/models/architecture_market.cpp
     ${CMAKE_SOURCE_DIR}/models/cards/convenient_store.cpp
-    ${CMAKE_SOURCE_DIR}/models/cards/landmark.cpp
-    ${CMAKE_SOURCE_DIR}/models/cards/forest.cpp
-    ${CMAKE_SOURCE_DIR}/models/cards/radio_tower.cpp
-    ${CMAKE_SOURCE_DIR}/models/cards/bakery.cpp
-    ${CMAKE_SOURCE_DIR}/models/cards/shopping_mall.cpp
-    ${CMAKE_SOURCE_DIR}/models/cards/mine.cpp
-    ${CMAKE_SOURCE_DIR}/models/cards/cheese_factory.cpp
-    ${CMAKE_SOURCE_DIR}/models/cards/family_restaurant.cpp
     ${CMAKE_SOURCE_DIR}/models/cards/wheat_field.cpp
     ${CMAKE_SOURCE_DIR}/models/cards/amusement_park.cpp
-    ${CMAKE_SOURCE_DIR}/models/cards/tv_station.cpp
-    ${CMAKE_SOURCE_DIR}/models/cards/cafe.cpp
-    ${CMAKE_SOURCE_DIR}/models/cards/train_station.cpp
-    ${CMAKE_SOURCE_DIR}/models/cards/business_center.cpp
-    ${CMAKE_SOURCE_DIR}/models/cards/apple_orchard.cpp
-    ${CMAKE_SOURCE_DIR}/models/cards/ranch.cpp
     ${CMAKE_SOURCE_DIR}/models/cards/building.cpp
-    ${CMAKE_SOURCE_DIR}/models/cards/furniture_factory.cpp
-    ${CMAKE_SOURCE_DIR}/models/cards/card.cpp
+    ${CMAKE_SOURCE_DIR}/models/cards/ranch.cpp
     ${CMAKE_SOURCE_DIR}/models/cards/fruit_and_vegetable_market.cpp
+    ${CMAKE_SOURCE_DIR}/models/cards/tv_station.cpp
+    ${CMAKE_SOURCE_DIR}/models/cards/family_restaurant.cpp
+    ${CMAKE_SOURCE_DIR}/models/cards/shopping_mall.cpp
+    ${CMAKE_SOURCE_DIR}/models/cards/bakery.cpp
+    ${CMAKE_SOURCE_DIR}/models/cards/apple_orchard.cpp
+    ${CMAKE_SOURCE_DIR}/models/cards/forest.cpp
+    ${CMAKE_SOURCE_DIR}/models/cards/cheese_factory.cpp
+    ${CMAKE_SOURCE_DIR}/models/cards/train_station.cpp
+    ${CMAKE_SOURCE_DIR}/models/cards/mine.cpp
     ${CMAKE_SOURCE_DIR}/models/cards/stadium.cpp
-    ${CMAKE_SOURCE_DIR}/models/architecture_market.cpp
+    ${CMAKE_SOURCE_DIR}/models/cards/furniture_factory.cpp
+    ${CMAKE_SOURCE_DIR}/models/cards/business_center.cpp
+    ${CMAKE_SOURCE_DIR}/models/cards/card.cpp
+    ${CMAKE_SOURCE_DIR}/models/cards/landmark.cpp
+    ${CMAKE_SOURCE_DIR}/models/cards/cafe.cpp
+    ${CMAKE_SOURCE_DIR}/models/cards/radio_tower.cpp
+    ${CMAKE_SOURCE_DIR}/models/hand.cpp
+    ${CMAKE_SOURCE_DIR}/models/machikoro_game.cpp
+    ${CMAKE_SOURCE_DIR}/models/events/init_game_event.cpp
 )
 set(E2E_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/e2e_test/e2e_main.cpp
-    ${CMAKE_SOURCE_DIR}/tests/e2e_test/test_def.h
-    ${CMAKE_SOURCE_DIR}/tests/e2e_test/e2e_init_game.cpp
     ${CMAKE_SOURCE_DIR}/tests/e2e_test/e2e_create_game.cpp
+    ${CMAKE_SOURCE_DIR}/tests/e2e_test/e2e_init_game.cpp
+    ${CMAKE_SOURCE_DIR}/tests/e2e_test/test_def.h
 )
 set(UNIT_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unittest/unit_operate_effect.cpp

--- a/models/architecture_market.cpp
+++ b/models/architecture_market.cpp
@@ -47,14 +47,12 @@ BuildingPtr ArchitectureMarket::drawCard(const CardName& name)
     return res;
 }
 
-std::map<CardName, std::vector<Building*>> ArchitectureMarket::cards() const
+std::map<CardName, int> ArchitectureMarket::cards() const
 {
-    std::map<CardName, std::vector<Building*>> res;
+    std::map<CardName, int> res;
     for (const auto& card : cards_)
     {
-        std::vector<Building*> buildings;
-        for (const auto& building : card.second) buildings.push_back(building.get());
-        res[card.first] = buildings;
+        res[card.first] = card.second.size();
     }
     return res;
 }

--- a/models/architecture_market.h
+++ b/models/architecture_market.h
@@ -19,7 +19,7 @@ public:
 
     BuildingPtr drawCard(const CardName& name);
 
-    std::map<CardName, std::vector<Building*>> cards() const;
+    std::map<CardName, int> cards() const;
 
 private:
     // All the building cards.

--- a/models/events/event_player.h
+++ b/models/events/event_player.h
@@ -1,0 +1,21 @@
+#ifndef MODELS_EVENTS_EVENT_PLAYER_H
+#define MODELS_EVENTS_EVENT_PLAYER_H
+
+#include <string>
+#include <map>
+
+/**
+ * @note: Used to pass the player's informations back to Presenter.
+ */
+class EventPlayer {
+public:
+    std::string player_name_;
+
+    int total_coin_ = 0;
+
+    std::map<std::string, bool> landmarks_;
+
+    std::map<std::string, int> buildings_;
+};
+
+#endif  // MODELS_EVENTS_EVENT_PLAYER_H

--- a/models/events/init_game_event.cpp
+++ b/models/events/init_game_event.cpp
@@ -1,0 +1,55 @@
+#include "models/events/init_game_event.h"
+
+#include "models/bank.h"
+#include "models/architecture_market.h"
+
+InitGameEvent::InitGameEvent(std::shared_ptr<UtilBase> util)
+    : util_(util)
+{
+}
+
+void InitGameEvent::set_bank(Bank* bank)
+{
+    if (!bank) return;
+    bank_balance_ = bank->totalCoin();
+}
+
+void InitGameEvent::set_market(ArchitectureMarket* market)
+{
+    if (!market) return;
+
+    auto cards = market->cards();
+    for (const auto& c : cards)
+    {
+        auto& [name, buildings] = c;
+        market_cards_[util_->getStringFromCardName(name)] = buildings.size();
+    }
+}
+
+void InitGameEvent::set_players(PlayerPtrs* players)
+{
+    if (!players) return;
+
+    for (auto& player : *players)
+    {
+        EventPlayer ep;
+        ep.player_name_ = player->name();
+        ep.total_coin_ = player->totalCoin();
+
+        // Landmarks.
+        auto landmarks = player->hand().landmarks();
+        for (const auto& card : landmarks)
+        {
+            ep.landmarks_[util_->getStringFromCardName(card->card_name())] = card->is_activate();
+        }
+
+        // Buildings.
+        auto buildings = player->hand().buildings();
+        for (const auto& card : buildings)
+        {
+            ep.buildings_[util_->getStringFromCardName(card->card_name())]++;
+        }
+
+        players_.push_back(std::move(ep));
+    }
+}

--- a/models/events/init_game_event.cpp
+++ b/models/events/init_game_event.cpp
@@ -21,8 +21,8 @@ void InitGameEvent::set_market(ArchitectureMarket* market)
     auto cards = market->cards();
     for (const auto& c : cards)
     {
-        auto& [name, buildings] = c;
-        market_cards_[util_->getStringFromCardName(name)] = buildings.size();
+        auto& [name, count] = c;
+        market_cards_[util_->getStringFromCardName(name)] = count;
     }
 }
 

--- a/models/events/init_game_event.h
+++ b/models/events/init_game_event.h
@@ -3,9 +3,13 @@
 
 #include <string>
 #include <vector>
+#include <map>
+#include <memory>
 
-#include "event.h"
 #include "models/player.h"
+#include "models/events/event.h"
+#include "models/events/event_player.h"
+#include "utils/util_base.h"
 
 class ArchitectureMarket;
 class Bank;
@@ -13,6 +17,8 @@ class Bank;
 class InitGameEvent : public Event {
 public:
     InitGameEvent() = default;
+
+    InitGameEvent(std::shared_ptr<UtilBase> util);
 
     ~InitGameEvent() = default;
 
@@ -24,32 +30,37 @@ public:
 
     std::string message() const override { return message_; }
 
-    void set_bank(Bank* bank) { bank_ = bank; }
+    void set_bank(Bank* bank);
 
-    Bank* bank() const { return bank_; }
+    int bank_balance() const { return bank_balance_; }
 
-    void set_market(ArchitectureMarket* market) { market_ = market; }
+    void set_market(ArchitectureMarket* market);
 
-    ArchitectureMarket* market() const { return market_; }
+    std::map<std::string, int> market_cards() const { return market_cards_; }
 
-    void set_players(PlayerPtrs* players) { players_ = players; }
+    void set_players(PlayerPtrs* players);
 
-    PlayerPtrs* players() const { return players_; }
+    std::vector<EventPlayer> players() const { return players_; }
 
     void set_player_name(const std::string& name) { player_name_ = name; }
 
     std::string player_name() const { return player_name_; }
 
 private:
+    std::shared_ptr<UtilBase> util_ = nullptr;
+
     StatusCode status_ = StatusCode::NoContent;
 
     std::string message_;
 
-    Bank* bank_ = nullptr;
+    // Bank's balance.
+    int bank_balance_ = 0;
 
-    ArchitectureMarket* market_ = nullptr;
+    // Market's cards.
+    std::map<std::string, int> market_cards_;
 
-    PlayerPtrs* players_ = nullptr;
+    // Players.
+    std::vector<EventPlayer> players_;
 
     // Player name for the next turn.
     std::string player_name_;

--- a/models/machikoro_game.cpp
+++ b/models/machikoro_game.cpp
@@ -3,8 +3,8 @@
 #include <vector>
 #include <string>
 
-#include "events/create_game_event.h"
-#include "events/init_game_event.h"
+#include "models/events/create_game_event.h"
+#include "models/events/init_game_event.h"
 
 MachiKoroGame::MachiKoroGame(std::shared_ptr<LoggerBase> logger, std::shared_ptr<UtilBase> util)
     : log_(logger)
@@ -37,7 +37,7 @@ std::unique_ptr<Event> MachiKoroGame::createGame(std::vector<PlayerPtr>&& player
 
 std::unique_ptr<Event> MachiKoroGame::initGame()
 {
-    auto event = std::make_unique<InitGameEvent>();
+    auto event = std::make_unique<InitGameEvent>(util_);
 
     // Allocate money.
     for (auto& player : players_) player->gainCoinFromBank(bank_, 3);

--- a/models/machikoro_game.h
+++ b/models/machikoro_game.h
@@ -52,7 +52,7 @@ private:
     PlayerPtrs players_;
 
     // Current player order.
-    // Mod by the number of players to know 
+    // Mod by the number of players to know
     // the players currently playing that round.
     int current_player_ = 0;
 };

--- a/presenters/init_game_present.cpp
+++ b/presenters/init_game_present.cpp
@@ -19,64 +19,63 @@ void InitGamePresenter::present(Event* event)
     status_ = static_cast<drogon::HttpStatusCode>(res->status());
 
     view_model_.reset();
-    view_model_ = std::make_unique<ViewModel>(
-        util_, res->message(), res->bank(), res->market(), res->players(), res->player_name());
+    view_model_ = std::make_unique<ViewModel>(util_,
+                                              res->message(),
+                                              res->bank_balance(),
+                                              res->market_cards(),
+                                              res->players(),
+                                              res->player_name());
 }
 
 InitGamePresenter::ViewModel::ViewModel(std::shared_ptr<UtilBase> util,
                                         const std::string& msg,
-                                        Bank* bank,
-                                        ArchitectureMarket* market,
-                                        PlayerPtrs* players,
+                                        int bank_balance,
+                                        const std::map<std::string, int>& market_cards,
+                                        const std::vector<EventPlayer>& players,
                                         const std::string& name)
     : util_(util)
     , message_(msg)
-    , bank_(bank)
-    , market_(market)
+    , bank_balance_(bank_balance)
+    , market_cards_(market_cards)
     , players_(players)
     , player_name_(name)
 {
-}
-
-InitGamePresenter::ViewModel::~ViewModel()
-{
-    bank_ = nullptr;
-    market_ = nullptr;
-    players_ = nullptr;
 }
 
 Json::Value InitGamePresenter::ViewModel::getJson() const
 {
     Json::Value res;
     res["Message"] = message_;
-    res["BankBalance"] = std::to_string(bank_->totalCoin());
+    res["BankBalance"] = std::to_string(bank_balance_);
 
     Json::Value market;
-    const auto& market_cards = market_->cards();
-    for (const auto& cards : market_cards)
+    for (const auto& cards : market_cards_)
     {
-        auto& [name, card] = cards;
-        market[util_->getStringFromCardName(name)] = std::to_string(card.size());
+        auto& [card_name, card_num] = cards;
+        market[card_name] = std::to_string(card_num);
     }
     res["Market"] = market;
 
     Json::Value players_json(Json::arrayValue);
-    for (auto& player : *players_)
+    for (auto& player : players_)
     {
         Json::Value player_json;
-        player_json["Name"] = player->name();
-        player_json["Money"] = player->totalCoin();
+        player_json["Name"] = player.player_name_;
+        player_json["Money"] = player.total_coin_;
 
         Json::Value hand_json;
-        for (auto& landmark : player->hand().landmarks())
-            hand_json[util_->getStringFromCardName(landmark->card_name())] =
-                landmark->is_activate();
+        for (const auto& landmark : player.landmarks_)
+        {
+            auto& [card_name, is_activate] = landmark;
+            hand_json[card_name] = is_activate;
+        }
 
         std::map<std::string, int> card_count;
-        for (auto& building : player->hand().buildings())
-            card_count[util_->getStringFromCardName(building->card_name())]++;
-        for (auto& building : card_count)
-            hand_json[building.first] = building.second;
+        for (const auto& building : player.buildings_)
+        {
+            auto& [card_name, count] = building;
+            card_count[card_name] = count;
+        }
 
         player_json["Hand"] = hand_json;
         players_json.append(player_json);

--- a/presenters/init_game_present.h
+++ b/presenters/init_game_present.h
@@ -7,10 +7,8 @@
 #include "json/value.h"
 #include "drogon/HttpTypes.h"
 #include "presenter.h"
-#include "models/player.h"
+#include "models/events/event_player.h"
 
-class ArchitectureMarket;
-class Bank;
 class Event;
 class UtilBase;
 
@@ -24,12 +22,12 @@ class InitGamePresenter : public Presenter {
 
         ViewModel(std::shared_ptr<UtilBase> util,
                   const std::string& msg,
-                  Bank* bank,
-                  ArchitectureMarket* market,
-                  PlayerPtrs* players,
+                  int bank_balance,
+                  const std::map<std::string, int>& market_cards,
+                  const std::vector<EventPlayer>& players,
                   const std::string& name);
 
-        ~ViewModel();
+        ~ViewModel() = default;
 
         Json::Value getJson() const;
 
@@ -39,11 +37,14 @@ class InitGamePresenter : public Presenter {
         // The self-defined message.
         std::string message_;
 
-        Bank* bank_ = nullptr;
+        // Bank balance.
+        int bank_balance_;
 
-        ArchitectureMarket* market_ = nullptr;
+        // Market cards.
+        std::map<std::string, int> market_cards_;
 
-        PlayerPtrs* players_ = nullptr;
+        // Players.
+        std::vector<EventPlayer> players_;
 
         // Player for the next turn.
         std::string player_name_;

--- a/utils/util.cpp
+++ b/utils/util.cpp
@@ -75,14 +75,13 @@ std::string Util::getStringFromCardName(const CardName& name)
         { CardName::FAMILY_RESTAURANT, "Family Restaurant" },
         { CardName::APPLE_ORCHARD, "Apple Orchard" },
         { CardName::FRUIT_AND_VEGETABLE_MARKET, "Fruit and Vegetable Market" },
-        { CardName::TRAIN_STATION, "Train Station"},
-        { CardName::SHOPPING_MALL, "Shopping Mall"},
-        { CardName::AMUSEMENT_PARK, "Amusement Park"},
-        { CardName::RADIO_TOWER, "Radio Tower"}
+        { CardName::TRAIN_STATION, "Train Station" },
+        { CardName::SHOPPING_MALL, "Shopping Mall" },
+        { CardName::AMUSEMENT_PARK, "Amusement Park" },
+        { CardName::RADIO_TOWER, "Radio Tower" }
     };
 
     auto it = cardNameStrings.find(name);
-    if (it != cardNameStrings.end())
-        return it->second;
+    if (it != cardNameStrings.end()) return it->second;
     return "Unknown CardName";
 }


### PR DESCRIPTION
1. Change the type of member variables in `InitGameEvent` due to prevent use the null pointer.
2. Change the return type of `ArchitectureMarket::cards()` because we won't use the Card (especially operate the card's effect) when call `ArchitectureMarket::cards()`.